### PR TITLE
add single dag pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ Repo containing common pyspark transformers for different pipelines
 - Set local pyenv version `pyenv local transformers`
 - Activate the virtual pyenv using `pyenv activate transformers`
 - Upgrade the pip package installer `pip install --upgrade pip`
-- Install poetry for package management `pip install poetry==1.5.1`
+- Install poetry for package management `pip install poetry==1.7.0`
 - Install dependencies from the lock file `poetry install --no-root` 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
 
 [tool.poetry]
 name = "tidal_per_transformers"
-version = "0.0.7"
+version = "0.0.8"
 description = "common transformers used by the tidal personalization team."
 authors = [
     "Loay <loay@squareup.com>",

--- a/tidal_per_transformers/transformers/single_dag_pipeline.py
+++ b/tidal_per_transformers/transformers/single_dag_pipeline.py
@@ -1,0 +1,24 @@
+from typing import List
+
+from pyspark.ml import Transformer
+
+
+class SingleDAGPipeline:
+    """This class creates a pipeline based on Transformers class
+    The main issue with pyspark.ml.pipeline is that each stage creates its own DAG, which does not
+    utilize spark new features like AQE and can lead to performance issues.
+    """
+    def __init__(self, stages: List[Transformer]):
+        """
+        :param stages: list of Transformers
+        """
+        self.stages = stages
+
+    def fit(self, dataset):
+        """
+        :param dataset: DataFrame
+        :return: PipelineModel
+        """
+        for stage in self.stages:
+            dataset = stage.transform(dataset)
+        return dataset


### PR DESCRIPTION
This implementation has lead to up to 62% speed up on synthetic tests vs [spark ml pipeline](https://spark.apache.org/docs/latest/ml-pipeline.html) due to staging limitation with [AQE](https://spark.apache.org/docs/latest/sql-performance-tuning.html#adaptive-query-execution) 
We expect even more gains on more complex pipelines with heavy datasets.