### PR TITLE
revert struct filter to being limited by a finite approved set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tidal_per_transformers"
-version = "0.4.1"
+version = "0.4.2"
 description = "common transformers used by the tidal personalization team."
 authors = [
     "Loay <loay@squareup.com>",

--- a/test/test_transformers/test_sequence_content_filter_transformer.py
+++ b/test/test_transformers/test_sequence_content_filter_transformer.py
@@ -19,9 +19,9 @@ class SequenceContentFilterTransformerTest(PySparkTest):
                                                     tracks=[Row(index=0,
                                                                 productId=1,
                                                                 title='S',
-                                                                trackGroup='96',
+                                                                trackGroup='95476336',
                                                                 albumId=1,
-                                                                artistId=1,
+                                                                artistId=27446,
                                                                 duration=183.0,
                                                                 masterBundle=6,
                                                                 audioQuality='LOSSLESS',
@@ -61,7 +61,6 @@ class SequenceContentFilterTransformerTest(PySparkTest):
                                                min_artist_streams=5_000,
                                                min_artist_streamers=1_000,
                                                ).transform(playlists)
-        res.collect()
 
         self.assertEqual(1, res.count())
 

--- a/tidal_per_transformers/transformers/master_bundle_filter_transformer.py
+++ b/tidal_per_transformers/transformers/master_bundle_filter_transformer.py
@@ -5,7 +5,7 @@ from pyspark.sql.dataframe import DataFrame
 
 import tidal_per_transformers.transformers.utils.constants as c
 from tidal_per_transformers.transformers.loggable_transformer import LoggableTransformer
-from tidal_per_transformers.transformers.track_group_filter_transformer import apply_category_filters
+from tidal_per_transformers.transformers.track_group_filter_transformer import apply_invalid_category_filters
 
 
 class MasterBundleFilterTransformer(LoggableTransformer):
@@ -88,11 +88,11 @@ class MasterBundleFilterTransformer(LoggableTransformer):
                                             ~F.col(c.ALBUM_TYPE).isin(album_types)
                                             ).select(c.MASTER_BUNDLE_ID)
 
-        category_filters = apply_category_filters(dataframe=category_filters,
-                                                  drop_holiday=drop_holiday,
-                                                  drop_ambient=drop_ambient,
-                                                  drop_children=drop_children,
-                                                  key=c.MASTER_BUNDLE_ID).select(c.MASTER_BUNDLE_ID)
+        category_filters = apply_invalid_category_filters(dataframe=category_filters,
+                                                          drop_holiday=drop_holiday,
+                                                          drop_ambient=drop_ambient,
+                                                          drop_children=drop_children,
+                                                          key=c.MASTER_BUNDLE_ID).select(c.MASTER_BUNDLE_ID)
 
         return (all_checks.union(category_filters).union(variant_albums) if drop_variant_versions
                 else all_checks.union(category_filters))

--- a/tidal_per_transformers/transformers/sequence_content_filter_transformer.py
+++ b/tidal_per_transformers/transformers/sequence_content_filter_transformer.py
@@ -76,12 +76,12 @@ class SequenceContentFilterTransformer(LoggableTransformer):
                 .where(F.size(c.TRACKS) > 0))  # Drop empty sequences
 
     def get_invalid_artists(self):
-        return ArtistFilterTransformer.apply_filters(self.artist_filters,
-                                                     self.min_artist_streams,
-                                                     self.min_artist_streamers,
-                                                     self.remove_holiday_music,
-                                                     self.remove_ambient_music,
-                                                     self.remove_children_music).select(c.ARTIST_ID)
+        return ArtistFilterTransformer.apply_invalid_filters(self.artist_filters,
+                                                             self.min_artist_streams,
+                                                             self.min_artist_streamers,
+                                                             self.remove_holiday_music,
+                                                             self.remove_ambient_music,
+                                                             self.remove_children_music).select(c.ARTIST_ID)
 
     def get_invalid_track_groups(self):
         return TrackGroupFilterTransformer.apply_filters(self.track_filters,

--- a/tidal_per_transformers/transformers/sequence_content_filter_transformer.py
+++ b/tidal_per_transformers/transformers/sequence_content_filter_transformer.py
@@ -15,6 +15,7 @@ class SequenceContentFilterTransformer(LoggableTransformer):
     Transformer for applying content filters to columns with lists of tracks. This can e.g. be applied to the
     playlist track table containing a list of all the tracks in a playlist.
     """
+
     def __init__(self,
                  track_filters: DataFrame,
                  artist_filters: DataFrame,
@@ -55,40 +56,37 @@ class SequenceContentFilterTransformer(LoggableTransformer):
         self.schema = schema
 
     def _transform(self, dataset):
-        artists_set = set(self.get_invalid_artists().toPandas()[c.ARTIST_ID].tolist())
+        artists_set = set(self.get_valid_artists().toPandas()[c.ARTIST_ID].tolist())
         artists_bc = dataset.sql_ctx.sparkSession.sparkContext.broadcast(artists_set)
 
-        tracks_set = set(self.get_invalid_track_groups().toPandas()[c.TRACK_GROUP].tolist())
+        tracks_set = set(self.get_valid_track_groups().toPandas()[c.TRACK_GROUP].tolist())
         tracks_bc = dataset.sql_ctx.sparkSession.sparkContext.broadcast(tracks_set)
 
         @F.udf(returnType=self.schema)
         def filter_tracks(tracks):
-            a_set = set(artists_bc.value)  # Ensure sets for faster lookups
+            a_set = set(artists_bc.value)
             t_set = set(tracks_bc.value)
 
-            return [
-                t for t in tracks
-                if t[c.ARTIST_ID] not in a_set and t[c.TRACK_GROUP] not in t_set
-            ]
+            return [t for t in tracks if t[c.ARTIST_ID] in a_set and t[c.TRACK_GROUP] in t_set]
 
         return (dataset
                 .withColumn(c.TRACKS, filter_tracks(c.TRACKS))
                 .where(F.size(c.TRACKS) > 0))  # Drop empty sequences
 
-    def get_invalid_artists(self):
-        return ArtistFilterTransformer.apply_invalid_filters(self.artist_filters,
-                                                             self.min_artist_streams,
-                                                             self.min_artist_streamers,
-                                                             self.remove_holiday_music,
-                                                             self.remove_ambient_music,
-                                                             self.remove_children_music).select(c.ARTIST_ID)
+    def get_valid_artists(self):
+        return ArtistFilterTransformer.apply_valid_filters(self.artist_filters,
+                                                           self.min_artist_streams,
+                                                           self.min_artist_streamers,
+                                                           self.remove_holiday_music,
+                                                           self.remove_ambient_music,
+                                                           self.remove_children_music).select(c.ARTIST_ID)
 
-    def get_invalid_track_groups(self):
-        return TrackGroupFilterTransformer.apply_filters(self.track_filters,
-                                                         self.min_track_streams,
-                                                         self.min_track_streamers,
-                                                         self.min_track_duration,
-                                                         self.max_track_duration,
-                                                         self.remove_holiday_music,
-                                                         self.remove_ambient_music,
-                                                         self.remove_children_music).select(c.TRACK_GROUP)
+    def get_valid_track_groups(self):
+        return TrackGroupFilterTransformer.apply_valid_filters(self.track_filters,
+                                                               self.min_track_streams,
+                                                               self.min_track_streamers,
+                                                               self.min_track_duration,
+                                                               self.max_track_duration,
+                                                               self.remove_holiday_music,
+                                                               self.remove_ambient_music,
+                                                               self.remove_children_music).select(c.TRACK_GROUP)

--- a/tidal_per_transformers/transformers/single_artist_filter_transformer.py
+++ b/tidal_per_transformers/transformers/single_artist_filter_transformer.py
@@ -36,10 +36,10 @@ class SingleArtistFilterTransformer(ArtistFilterTransformer):
         self.min_artist_streams = min_artist_streams
 
     def _transform(self, dataset):
-        filtered_artists = self.apply_filters(self.artist_filters,
-                                              self.min_artist_streams,
-                                              self.min_artist_streamers,
-                                              self.remove_holiday_music,
-                                              self.remove_ambient_music,
-                                              self.remove_children_music)
+        filtered_artists = self.apply_invalid_filters(self.artist_filters,
+                                                      self.min_artist_streams,
+                                                      self.min_artist_streamers,
+                                                      self.remove_holiday_music,
+                                                      self.remove_ambient_music,
+                                                      self.remove_children_music)
         return dataset.join(filtered_artists, c.ARTIST_ID, how="left_anti")

--- a/tidal_per_transformers/transformers/track_group_filter_transformer.py
+++ b/tidal_per_transformers/transformers/track_group_filter_transformer.py
@@ -46,26 +46,26 @@ class TrackGroupFilterTransformer(LoggableTransformer):
         return self.filter_tracks(dataset)
 
     def filter_tracks(self, tracks: DataFrame) -> DataFrame:
-        filtered_tracks = self.apply_filters(self.track_filters,
-                                             self.min_track_streams,
-                                             self.min_track_streamers,
-                                             self.min_track_duration,
-                                             self.max_track_duration,
-                                             self.remove_holiday_music,
-                                             self.remove_ambient_music,
-                                             self.remove_children_music)
+        filtered_tracks = self.apply_invalid_filters(self.track_filters,
+                                                     self.min_track_streams,
+                                                     self.min_track_streamers,
+                                                     self.min_track_duration,
+                                                     self.max_track_duration,
+                                                     self.remove_holiday_music,
+                                                     self.remove_ambient_music,
+                                                     self.remove_children_music)
 
         return tracks.join(filtered_tracks, c.TRACK_GROUP, how="left_anti")
 
     @staticmethod
-    def apply_filters(category_filters: DataFrame,
-                      stream_count: int,
-                      streamers_count: int,
-                      min_track_duration: int,
-                      max_track_duration: int,
-                      drop_holiday: bool,
-                      drop_ambient: bool,
-                      drop_children: bool):
+    def apply_invalid_filters(category_filters: DataFrame,
+                              stream_count: int,
+                              streamers_count: int,
+                              min_track_duration: int,
+                              max_track_duration: int,
+                              drop_holiday: bool,
+                              drop_ambient: bool,
+                              drop_children: bool):
         all_checks = category_filters.where((F.col(c.AVAILABLE) == False) |
                                             (F.col(c.NON_MUSIC) == 1) |
                                             (F.col(c.STREAM_COUNT) < stream_count) |
@@ -78,6 +78,27 @@ class TrackGroupFilterTransformer(LoggableTransformer):
                                                           drop_children=drop_children,
                                                           key=c.TRACK_GROUP).select(c.TRACK_GROUP)
         return all_checks.union(category_filters)
+
+    @staticmethod
+    def apply_valid_filters(category_filters: DataFrame,
+                            stream_count: int,
+                            streamers_count: int,
+                            min_track_duration: int,
+                            max_track_duration: int,
+                            drop_holiday: bool,
+                            drop_ambient: bool,
+                            drop_children: bool):
+        df = category_filters.where((F.col(c.AVAILABLE) == True) &
+                                    (F.col(c.NON_MUSIC) == 0) &
+                                    (F.col(c.STREAM_COUNT) >= stream_count) &
+                                    (F.col(c.STREAMERS_COUNT) >= streamers_count) &
+                                    F.col(c.DURATION).between(min_track_duration, max_track_duration)
+                                    )
+        return apply_valid_category_filters(dataframe=df,
+                                            drop_holiday=drop_holiday,
+                                            drop_ambient=drop_ambient,
+                                            drop_children=drop_children,
+                                            key=c.TRACK_GROUP).select(c.TRACK_GROUP)
 
 
 def apply_invalid_category_filters(dataframe: DataFrame,


### PR DESCRIPTION
while this will lead to filtering out artists who are not handled by music understanding models, the space complexity of checking all artists for each song, and not invalid artists breaks scalability, reverting for struct method as a middle ground 